### PR TITLE
Add model download selector

### DIFF
--- a/sam2-cli/MainCommand.swift
+++ b/sam2-cli/MainCommand.swift
@@ -47,11 +47,16 @@ struct MainCommand: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "The directory containing the model files.")
     var modelDirectory: String? = nil
 
+    @Option(name: .shortAndLong, help: "The directory to download the model snapshot.")
+    var downloadDirectory: String? = nil
+
     @MainActor
     mutating func run() async throws {
         let sam: SAM2
         if let modelDirectory = modelDirectory {
             sam = try await SAM2.load(from: URL(fileURLWithPath: modelDirectory))
+        } else if let downloadDirectory = downloadDirectory {
+            sam = try await SAM2.load(from: URL(fileURLWithPath: downloadDirectory))
         } else {
             sam = try await SAM2.load()
         }

--- a/sam2-cli/MainCommand.swift
+++ b/sam2-cli/MainCommand.swift
@@ -44,10 +44,17 @@ struct MainCommand: AsyncParsableCommand {
     @Option(name: [.long, .customShort("k")], help: "The output file name for the segmentation mask.")
     var mask: String? = nil
 
+    @Option(name: .shortAndLong, help: "The directory containing the model files.")
+    var modelDirectory: String? = nil
+
     @MainActor
     mutating func run() async throws {
-        // TODO: specify directory with loadable .mlpackages instead
-        let sam = try await SAM2.load()
+        let sam: SAM2
+        if let modelDirectory = modelDirectory {
+            sam = try await SAM2.load(from: URL(fileURLWithPath: modelDirectory))
+        } else {
+            sam = try await SAM2.load()
+        }
         print("Models loaded in: \(String(describing: sam.initializationTime))")
         let targetSize = sam.inputSize
 


### PR DESCRIPTION
Fixes #28

Add model download selector and update model loading process.

* **sam2-cli/MainCommand.swift**
  - Add an option to specify the model directory.
  - Modify the `run` function to use the specified model directory for loading models.

* **SAM2-Demo/Common/SAM2.swift**
  - Add a function to download the model snapshot using the `snapshot` function from `HubApi.swift`.
  - Modify the `loadModels` function to call the new download function before loading the models.
  - Add a new `load(from directory: URL)` function to load models from a specified directory.

